### PR TITLE
Fix issue #6

### DIFF
--- a/install_kicad.sh
+++ b/install_kicad.sh
@@ -20,4 +20,3 @@ if [ -d support/demos ]; then
 fi
 
 mv bin/demos support/
-rm -r bin/doc #we do not have scripting support yet


### PR DESCRIPTION
The bin/doc directory does not exist anymore upstream in KiCad, so we
should not remove it.

The upstream change was b813eac254cc0f138839525943ee78e714173d4a.