### PR TITLE
compile_kicad.py: more robust OCE directory search

### DIFF
--- a/compile_kicad.py
+++ b/compile_kicad.py
@@ -16,8 +16,8 @@ def which(program_name):
 
 
 def find_oce():
-    cmd = ["find", "/usr/local/Cellar/oce", "-name", "Resources"]
-    return subprocess.check_output(cmd).strip()
+    oce_cellar = subprocess.check_output(["brew", "--cellar", "oce"]).strip()
+    return subprocess.check_output(["find", oce_cellar, "-name", "Resources"]).strip()
 
 
 CMAKE_SETTINGS = ["-DDEFAULT_INSTALL_PATH=/Library/Application Support/kicad",


### PR DESCRIPTION
As suggested by Nick in a [comment](https://github.com/wayneandlayne/KiCadMacOSPackaging/commit/76e1107ed771a49d4995fbc405580739abc80238#commitcomment-28667199) regarding the last PR.
